### PR TITLE
[Fix] 장바구니 footer 버튼 감추는 조건 수정

### DIFF
--- a/domain/src/main/java/com/woowahan/domain/model/CartListItemModel.kt
+++ b/domain/src/main/java/com/woowahan/domain/model/CartListItemModel.kt
@@ -7,6 +7,7 @@ sealed class CartListItemModel {
         val price: Long,
         val recentViewedItems: List<RecentViewedItemModel>,
         val deliveryFee: Long = 2500L,
+        val showPriceInfo: Boolean
     ) : CartListItemModel() {
         val totalPrice: Long = price + deliveryFee
     }

--- a/domain/src/main/java/com/woowahan/domain/usecase/cart/FetchCartItemsUseCase.kt
+++ b/domain/src/main/java/com/woowahan/domain/usecase/cart/FetchCartItemsUseCase.kt
@@ -21,7 +21,8 @@ class FetchCartItemsUseCase(
                                 CartListItemModel.Content(CartModel.empty()),
                                 CartListItemModel.Footer(
                                     price = 0L,
-                                    recentViewedItems = recentViewedList.getOrThrow()
+                                    recentViewedItems = recentViewedList.getOrThrow(),
+                                    showPriceInfo = cartList.isEmpty()
                                 )
                             )
                         )
@@ -34,7 +35,8 @@ class FetchCartItemsUseCase(
                         ) + cartList.map { CartListItemModel.Content(it) } + listOf(
                             CartListItemModel.Footer(
                                 price = price,
-                                recentViewedItems = recentViewedList.getOrThrow()
+                                recentViewedItems = recentViewedList.getOrThrow(),
+                                showPriceInfo = cartList.isEmpty()
                             )
                         ))
                     }
@@ -45,10 +47,11 @@ class FetchCartItemsUseCase(
             emit(
                 DomainEvent.failure(
                     it, listOf(
-                        CartListItemModel.Header(false),
+                        CartListItemModel.Content(CartModel.empty()),
                         CartListItemModel.Footer(
                             price = 0L,
-                            recentViewedItems = emptyList()
+                            recentViewedItems = emptyList(),
+                            showPriceInfo = false
                         )
                     )
                 )

--- a/presentation/src/main/java/com/woowahan/banchan/extension/DateExtension.kt
+++ b/presentation/src/main/java/com/woowahan/banchan/extension/DateExtension.kt
@@ -18,7 +18,11 @@ fun Date.getTimeString(): String {
                 "${hour}시간전"
             else{
                 val min = TimeUnit.MILLISECONDS.toMinutes(lastDateMill)
-                "${min}분전"
+                if (min == 0L){
+                    "방금전"
+                }else {
+                    "${min}분전"
+                }
             }
         }
         year>0 -> {

--- a/presentation/src/main/java/com/woowahan/banchan/ui/adapter/DefaultCartAdapter.kt
+++ b/presentation/src/main/java/com/woowahan/banchan/ui/adapter/DefaultCartAdapter.kt
@@ -182,6 +182,7 @@ class DefaultCartAdapter(
         }
 
         fun bindTotalPrice(item: CartListItemModel.Footer) {
+            binding.showPrice = item.showPriceInfo
             binding.menuPrice = item.price
             binding.totalPrice = item.totalPrice
             binding.btnEnabled = (10000L <= item.price)

--- a/presentation/src/main/res/layout/item_cart_footer.xml
+++ b/presentation/src/main/res/layout/item_cart_footer.xml
@@ -43,6 +43,10 @@
             type="String" />
 
         <variable
+            name="showPrice"
+            type="Boolean" />
+
+        <variable
             name="recentViewedAdapter"
             type="com.woowahan.banchan.ui.adapter.RecentViewedHorizontalAdapter" />
     </data>
@@ -56,7 +60,7 @@
             android:id="@+id/layout_upper"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:visibility="@{menuPrice == 0 ? View.GONE : View.VISIBLE}"
+            android:visibility="@{showPrice ? View.GONE : View.VISIBLE}"
             app:layout_constraintTop_toTopOf="parent">
 
             <TextView


### PR DESCRIPTION
## 📪  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
기존의 장바구니 화면의 footer price info 를 감추는 조건은 메뉴의 가격이 0원일 때 감추는 것으로 했다.
하지만 이러니까 장바구니의 아이템은 있지만 선택한 아이템이 없어서 메뉴의 가격이 0원일 때에도 감춰졌다.
그래서 `UseCase`에서 아이템을 받아올 때 비어있는지, 있는지 체크하여 `visibility`를 조절함

## 📚  What's-New
<!-- 한 일들을 적어주세요. -->
- [x] Price info visibility 조절

close #129 
