### PR TITLE
[Fix] CartItem 제거시 Exception 발생 수정

### DIFF
--- a/data/src/main/java/com/woowahan/data/datasource/CartDataSourceImpl.kt
+++ b/data/src/main/java/com/woowahan/data/datasource/CartDataSourceImpl.kt
@@ -6,6 +6,7 @@ import com.woowahan.data.entity.dto.CartEntity
 import com.woowahan.data.entity.table.BanchanItemTableEntity
 import com.woowahan.data.entity.table.CartTableEntity
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
@@ -30,6 +31,17 @@ class CartDataSourceImpl @Inject constructor(
         val res = cartDao.removeCartItem(*hashes)
         banchanDao.removeBanchanItems(*hashes)
         emit(res)
+    }.catch {
+        when(it){
+            is android.database.sqlite.SQLiteConstraintException -> {
+                println("SQLiteConstraintException debug => ${it.message}, ${it.message?.contains("1811")}")
+                it.printStackTrace()
+                if(it.message?.contains("1811") == true)
+                    emit(hashes.size)
+                else
+                    throw it
+            }
+        }
     }
 
     // 항목 개수 업데이트 -> 이때 기존에 없는 항목을 업데이트 시도한다면 null 을 리턴받을것


### PR DESCRIPTION
## 📪  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #138 

Cart, RecentViewd가 같은 ItemTable을 참조하므로 제약을 추가해놨는데, 
해당 제약으로인해 정상적으로 Item 삭제가 방지될때, Exception이 전달되어 실패처리 되는 문제 수정

## 📚  What's-New
<!-- 한 일들을 적어주세요. -->
- [x]  CartDataSource에서 해당 경우를 catch 하여, 성공처리로 emit 해주도록 수정
