### PR TITLE
[Fix] OrderList에서 가격정보가 단일 Item 가격만 표시되는 문제 수정

### DIFF
--- a/domain/src/main/java/com/woowahan/domain/model/OrderModel.kt
+++ b/domain/src/main/java/com/woowahan/domain/model/OrderModel.kt
@@ -52,8 +52,11 @@ data class OrderModel(
     val orderId: Long,
     val time: Date?,
     val items: List<OrderItemModel>,
-    val deliveryState: Boolean
-)
+    val deliveryState: Boolean,
+    val deliveryFee: Long
+){
+    val totalPrice = items.sumOf { it.price * it.count }
+}
 
 data class OrderItemModel(
     val hash: String,

--- a/domain/src/main/java/com/woowahan/domain/usecase/order/FetchOrderUseCase.kt
+++ b/domain/src/main/java/com/woowahan/domain/usecase/order/FetchOrderUseCase.kt
@@ -26,10 +26,10 @@ class FetchOrderUseCase(
                 ) + it.items.map { item ->
                     OrderItemTypeModel.Order(item)
                 } + listOf(
-                    it.items.sumOf { item -> item.price * item.count }.run {
+                    it.totalPrice.run {
                         OrderItemTypeModel.Footer(
                             this,
-                            if(this >= DeliveryConstant.FreeDeliveryFeePrice) DeliveryConstant.FreeDeliveryFeePrice else DeliveryConstant.DeliveryFee
+                            it.deliveryFee
                         )
                     }
                 )

--- a/presentation/src/main/java/com/woowahan/banchan/ui/order/OrderListAdapter.kt
+++ b/presentation/src/main/java/com/woowahan/banchan/ui/order/OrderListAdapter.kt
@@ -80,7 +80,7 @@ class OrderListAdapter(
                 binding.imageUrl = it.imageUrl
                 binding.title = it.title
             }
-            binding.price = item.items.sumOf { it.price }
+            binding.price = item.totalPrice + item.deliveryFee
             bindDeliveryState(item.deliveryState)
             binding.itemSize = item.items.size
             binding.order = item

--- a/presentation/src/main/res/layout/item_order_list.xml
+++ b/presentation/src/main/res/layout/item_order_list.xml
@@ -67,7 +67,7 @@
 
         <TextView
             android:textStyle="bold"
-            android:text="@{@string/order_items_title(title, itemSize)}"
+            android:text="@{itemSize>1 ? @string/order_items_title(title, itemSize) : title}"
             android:id="@+id/tv_title"
             app:layout_constraintStart_toEndOf="@id/iv_image"
             app:layout_constraintBottom_toTopOf="@id/tv_price"


### PR DESCRIPTION
## 📪  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #143 
## 📚  What's-New
<!-- 한 일들을 적어주세요. -->
- [x] 배송료 적용
- [x] Item 개수를 가격에 적용
- [x] OrderList 비어있는 경우 대응
- [x] 주문한 item이 single item 인 경우 title에 적용

close #143 
