### PR TITLE
[Fix] RecentViewed Item의 Hash가 같은데, Replace되지 않고 Insert되는 문제 수정

### DIFF
--- a/data/src/main/java/com/woowahan/data/entity/table/RecentViewedTableEntity.kt
+++ b/data/src/main/java/com/woowahan/data/entity/table/RecentViewedTableEntity.kt
@@ -1,9 +1,6 @@
 package com.woowahan.data.entity.table
 
-import androidx.room.ColumnInfo
-import androidx.room.Entity
-import androidx.room.ForeignKey
-import androidx.room.PrimaryKey
+import androidx.room.*
 
 @Entity(
     tableName = RecentViewedTableEntity.TABLE_NAME,
@@ -15,7 +12,8 @@ import androidx.room.PrimaryKey
             onDelete = ForeignKey.RESTRICT,
             onUpdate = ForeignKey.CASCADE
         )
-    ]
+    ],
+    indices = [Index(value = [RecentViewedTableEntity.COLUMN_HASH], unique = true)]
 )
 data class RecentViewedTableEntity(
     @ColumnInfo(name = COLUMN_HASH) val hash: String,


### PR DESCRIPTION
- RecentViewed Table Entity의 PK를 변경함으로 인해 hash값에 따라 insert or replace 제약이 작동하지 않게 되었다
- hash를 unique 로 설정하여 해결

## 📪  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #166 
## 📚  What's-New
<!-- 한 일들을 적어주세요. -->
- [x] RecentViewed Item의 Hash가 같은데, Replace되지 않고 Insert되는 문제 수정

close #166